### PR TITLE
Small speaking page edits

### DIFF
--- a/src/speaking/index.html
+++ b/src/speaking/index.html
@@ -36,7 +36,13 @@ description: >
 
       <p>Please see our <a href="/covid/">COVID-19 Policy</a> for more information.</p>
 
-      <p>At this time, we are planning on most presenters being in Durham to present their talks in person. Things may always change depending on how the pandemic progresses over the year. As in 2022, we will have a handful of online-exclusive talks that will air during the in-person breaks and meals.</p>
+      <p>
+        At this time, we are planning on most presenters being in Durham to
+        present their talks in person. Things may always change depending on
+        public health needs. As in 2022 and 2023, we will have a handful of
+        online-exclusive talks that will air during the in-person breaks and
+        meals.
+      </p>
 
       <p>Please indicate your format preference (in-person or online) as part of your proposal.</p>
 

--- a/src/speaking/index.html
+++ b/src/speaking/index.html
@@ -69,7 +69,9 @@ description: >
 
       <p>Just like in 2023, most talks will be in-person, and we will have several online-exclusive talks that air during breaks in the in-person session. These will air across all three talk days (Monday through Wednesday). Please indicate your preference for online or in-person in your submissions. There’s a required question in pretalx asking your preference.</p>
 
-      <h3 id="deep-dive-talks-september-18th">Deep Dive Talks (September 18th)</h3>
+      <h3 id="deep-dive-talks-september-25th">
+        Deep Dive Talks (September 25th)
+      </h3>
 
       <p>This year, we will be curating a deep dive day to focus on exploring Django and Django-adjacent topics in detail.
       Deep dive day is meant to follow in the footsteps of <a href="https://djangounderthehood.com/">Django Under the Hood</a> and will provide a range of topics presented in-depth, targeting varying levels of Django experience.

--- a/src/speaking/index.html
+++ b/src/speaking/index.html
@@ -59,10 +59,18 @@ description: >
       <p>Here are some examples of what has been accepted over the last couple of years:</p>
 
       <ul>
-        <li><a href="https://2022.djangocon.us/talks/">DjangoCon US 2022 Talks</a></li>
-        <li><a href="https://2021.djangocon.us/talks/">DjangoCon US 2021 Talks</a></li>
-        <li><a href="https://2019.djangocon.us/talks/">DjangoCon US 2019 Talks</a></li>
-        <li><a href="https://2018.djangocon.us/talks/">DjangoCon US 2018 Talks</a></li>
+        <li>
+          <a href="https://2023.djangocon.us/talks/">DjangoCon US 2023 Talks</a>
+        </li>
+        <li>
+          <a href="https://2022.djangocon.us/talks/">DjangoCon US 2022 Talks</a>
+        </li>
+        <li>
+          <a href="https://2021.djangocon.us/talks/">DjangoCon US 2021 Talks</a>
+        </li>
+        <li>
+          <a href="https://2019.djangocon.us/talks/">DjangoCon US 2019 Talks</a>
+        </li>
       </ul>
 
       <h4 id="online-talks">Online talks</h4>


### PR DESCRIPTION
1. Fixes a quick off-by-one-week error
2. Cycles 2018 off our previous years' talks and brings in 2023
3. Updates verbiage about online vs in-person to be less covid-focused