### PR TITLE
Adds Markdown shortcode

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,10 +1,11 @@
 const path = require('path');
 
 const Image = require('@11ty/eleventy-img');
-const markdownIt = require("markdown-it");
 
 const setupCollections = require('./lib/collections');
 const setupFeed = require('./lib/feed');
+const markdown = require('./lib/markdown');
+const outdent = require('outdent');
 
 module.exports = (config) => {
   setupCollections(config);
@@ -66,16 +67,14 @@ module.exports = (config) => {
     return Image.generateHTML(metadata, imageAttributes);
   });
 
+  config.addPairedShortcode("markdown", function(content = "") {
+    return markdown.render(content);
+  });
+
   /*
     Filters
   */
   config.addFilter("markdown", function(content = "") {
-    let markdown = markdownIt({
-      html: true,
-      breaks: true,
-      linkify: true
-    });
-
     return markdown.render(content);
   });
 
@@ -87,6 +86,8 @@ module.exports = (config) => {
     excerpt_separator: "<!-- excerpt -->"
   });
 
+  config.setLibrary("md", markdown);
+
   return {
     dir: {
       input: "src",
@@ -96,7 +97,6 @@ module.exports = (config) => {
 
     // Use Liquid for templating
     // https://www.11ty.dev/docs/languages/liquid/
-    htmlTemplateEngine: "liquid",
-    markdownTemplateEngine: "liquid"
+    htmlTemplateEngine: "liquid"
   }
 };

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,0 +1,17 @@
+const markdownIt = require("markdown-it");
+const markdownItAnchor = require("markdown-it-anchor");
+
+const markdown = markdownIt({
+    html: true,
+    breaks: true,
+    linkify: true
+  })
+  .use(markdownItAnchor, {
+    // The level option defines the minimum level of headings to apply anchors to.
+    // 1 applies to all headings. 2 will apply to h2 and below, etc.
+    level: 1,
+    // The slugify option is a function that transforms the heading text into a URL fragment identifier.
+    slugify: markdownItAnchor.defaults.slugify
+});
+
+module.exports = markdown;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "durham.djangocon.us",
       "version": "1.0.0",
       "dependencies": {
-        "@11ty/eleventy-plugin-rss": "^1.2.0"
+        "markdown-it-anchor": "^9.0.1",
+        "outdent": "^0.8.0"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
         "@11ty/eleventy-img": "^4.0.2",
+        "@11ty/eleventy-plugin-rss": "^1.2.0",
         "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/typography": "^0.5.10",
         "autoprefixer": "^10.4.18",
@@ -176,6 +178,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.2.0.tgz",
       "integrity": "sha512-YzFnSH/5pObcFnqZ2sAQ782WmpOZHj1+xB9ydY/0j7BZ2jUNahn53VmwCB/sBRwXA/Fbwwj90q1MLo01Ru0UaQ==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "posthtml": "^0.16.6",
@@ -1080,6 +1083,28 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "peer": true
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -1131,7 +1156,8 @@
     "node_modules/any-promise": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
-      "integrity": "sha512-lqzY9o+BbeGHRCOyxQkt/Tgvz0IZhTmQiA+LxQW8wSNpcTbj8K+0cZiSEvbpNZZP9/11Gy7dnLO3GNWUXO4d1g=="
+      "integrity": "sha512-lqzY9o+BbeGHRCOyxQkt/Tgvz0IZhTmQiA+LxQW8wSNpcTbj8K+0cZiSEvbpNZZP9/11Gy7dnLO3GNWUXO4d1g==",
+      "dev": true
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -1911,6 +1937,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1992,6 +2019,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
       "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -2005,6 +2033,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -2013,6 +2042,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2024,6 +2054,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -2038,6 +2069,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -2105,6 +2137,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
       "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -2650,6 +2683,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
       "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -2668,6 +2702,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-1.0.0.tgz",
       "integrity": "sha512-TScO04soylRN9i/QdOdgZyhydXg9z6XdaGzEyOgDKycePeDeTT4KvigjBcI+tgfTlieLWauGORMq5F1eIDa+1w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -2828,7 +2863,8 @@
     "node_modules/is-json": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA=="
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -3023,7 +3059,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -3060,7 +3095,8 @@
     "node_modules/list-to-array": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/list-to-array/-/list-to-array-1.1.0.tgz",
-      "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g=="
+      "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g==",
+      "dev": true
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -3129,7 +3165,6 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.0.0.tgz",
       "integrity": "sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -3142,17 +3177,24 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-it-anchor": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.0.1.tgz",
+      "integrity": "sha512-cBt7aAzmkfX8X7FqAe8EBryiKmToXgMQEEMqkXzWCm0toDtfDYIGboKeTKd8cpNJArJtutrf+977wFJTsvNGmQ==",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -3214,8 +3256,7 @@
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3311,7 +3352,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
@@ -3511,6 +3553,11 @@
         "wrappy": "1"
       }
     },
+    "node_modules/outdent": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -3551,7 +3598,8 @@
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "dev": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -4357,6 +4405,7 @@
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
       "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+      "dev": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -4369,6 +4418,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
       "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "dev": true,
       "dependencies": {
         "htmlparser2": "^7.1.1"
       },
@@ -4380,6 +4430,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
       "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "dev": true,
       "dependencies": {
         "is-json": "^2.0.1"
       },
@@ -4391,6 +4442,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/posthtml-urls/-/posthtml-urls-1.0.0.tgz",
       "integrity": "sha512-CMJ0L009sGQVUuYM/g6WJdscsq6ooAwhUuF6CDlYPMLxKp2rmCYVebEU+wZGxnQstGJhZPMvXsRhtqekILd5/w==",
+      "dev": true,
       "dependencies": {
         "http-equiv-refresh": "^1.0.0",
         "list-to-array": "^1.1.0",
@@ -4423,6 +4475,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
       "integrity": "sha512-67roqt1k3QDA41DZ8xi0V+rF3GoaMiX7QilbXu0vXimut+9RcKBNZ/t60xCRgcsihmNUsEjh48xLfNqOrKblUg==",
+      "dev": true,
       "dependencies": {
         "any-promise": "^0.1.0"
       }
@@ -4561,7 +4614,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5312,8 +5364,7 @@
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1",
     "@11ty/eleventy-img": "^4.0.2",
-    "@tailwindcss/container-queries": "^0.1.1",
     "@11ty/eleventy-plugin-rss": "^1.2.0",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/typography": "^0.5.10",
     "autoprefixer": "^10.4.18",
     "concurrently": "^8.2.2",
@@ -47,5 +47,9 @@
     "postcss-import": "^16.0.1",
     "tailwindcss": "^3.4.1",
     "yaml": "^2.4.1"
+  },
+  "dependencies": {
+    "markdown-it-anchor": "^9.0.1",
+    "outdent": "^0.8.0"
   }
 }

--- a/src/_layouts/post.html
+++ b/src/_layouts/post.html
@@ -20,7 +20,7 @@ templateClass: view-post
         </figure>
       {% endif %}
 
-      {{ content }}
+      {{ content | markdown }}
     </div>
   </div>
 </article>

--- a/src/speaking/index.html
+++ b/src/speaking/index.html
@@ -17,123 +17,88 @@ description: >
 <div class="pt-0 block-container">
   <div class="wrapper">
     <div class="prose lg:prose-lg">
-      <p>Our Call for Proposals is now closed. Decision notifications will be sent by July 8th, 2024.</p>
+      {% markdown %}
+Our Call for Proposals is now closed. Decision notifications will be sent by July 8th, 2024.
 
-      <h2 id="why-speak-at-djangocon-us">Why Speak at DjangoCon US?</h2>
+## Why Speak at DjangoCon US?
 
-      <ul>
-        <li>Presenters receive a <strong>free ticket</strong> to DjangoCon US and up to <strong>$500 in travel cost reimbursement!</strong>
-      </li>
-        <li>A professionally produced video of your talk will be published on our YouTube channel. (You may opt-out of this.)</li>
-        <li>Professional photographer on hand to photograph your talk. (Also optional.)</li>
-        <li>Expose the Django community to new tools, practices, or ideas.</li>
-        <li>Expand your technical, professional, and personal networks.</li>
-        <li>Share your discoveries with a large audience.</li>
-        <li>Give back to the Django community!</li>
-      </ul>
+*   Presenters receive a **free ticket** to DjangoCon US and up to **$500 in travel cost reimbursement!**
+*   A professionally produced video of your talk will be published on our YouTube channel. (You may opt-out of this.)
+*   Professional photographer on hand to photograph your talk. (Also optional.)
+*   Expose the Django community to new tools, practices, or ideas.
+*   Expand your technical, professional, and personal networks.
+*   Share your discoveries with a large audience.
+*   Give back to the Django community!
 
-      <h3 id="covid-19">COVID-19</h3>
+### COVID-19
 
-      <p>Please see our <a href="/covid/">COVID-19 Policy</a> for more information.</p>
+Please see our [COVID-19 Policy](/covid/) for more information.
 
-      <p>
-        At this time, we are planning on most presenters being in Durham to
-        present their talks in person. Things may always change depending on
-        public health needs. As in 2022 and 2023, we will have a handful of
-        online-exclusive talks that will air during the in-person breaks and
-        meals.
-      </p>
+At this time, we are planning on most presenters being in Durham to present their talks in person. Things may always change depending on public health needs. As in 2022 and 2023, we will have a handful of online-exclusive talks that will air during the in-person breaks and meals.
 
-      <p>Please indicate your format preference (in-person or online) as part of your proposal.</p>
+Please indicate your format preference (in-person or online) as part of your proposal.
 
-      <h2 id="proposing-to-djangocon-us">Proposing to DjangoCon US</h2>
+## Proposing to DjangoCon US
 
-      <h3 id="selection-process">Selection process</h3>
+### Selection process
 
-      <p>We’ll choose a selection of talks and tutorials that we feel add to the most enjoyable and engaging program for our attendees. Volunteers from the Django community are invited to help us pick talks, and we rely heavily on them to help us select interesting and beneficial ones for our attendees. Community volunteers and conference organizers will review anonymized submissions and collectively decide which ones to accept.</p>
+We’ll choose a selection of talks and tutorials that we feel add to the most enjoyable and engaging program for our attendees. Volunteers from the Django community are invited to help us pick talks, and we rely heavily on them to help us select interesting and beneficial ones for our attendees. Community volunteers and conference organizers will review anonymized submissions and collectively decide which ones to accept.
 
-      <h3 id="talks-september-23rd-24th-25th">Talks (September 23rd, 24th, &amp; 25th)</h3>
+### Talks (September 23rd, 24th, & 25th)
 
-      <p>Length: 25 minutes or 45 minutes</p>
+Length: 25 minutes or 45 minutes
 
-      <p><strong>NOTE</strong> For online talks especially, these times are a hard limit and cannot be exceeded.</p>
+**NOTE** For online talks especially, these times are a hard limit and cannot be exceeded.
 
-      <p>We are looking for original and exciting talks that can benefit the diverse interests of our audience.
-      Don’t feel boxed into Django-centric themes; we also love talks about community, web development, user experience, etc.
-      If you’re a first-timer - don’t fret! We would love to be remembered as the conference where you started your speaking career.</p>
+We are looking for original and exciting talks that can benefit the diverse interests of our audience. Don’t feel boxed into Django-centric themes; we also love talks about community, web development, user experience, etc. If you’re a first-timer - don’t fret! We would love to be remembered as the conference where you started your speaking career.
 
-      <p>Here are some examples of what has been accepted over the last couple of years:</p>
+Here are some examples of what has been accepted over the last couple of years:
 
-      <ul>
-        <li>
-          <a href="https://2023.djangocon.us/talks/">DjangoCon US 2023 Talks</a>
-        </li>
-        <li>
-          <a href="https://2022.djangocon.us/talks/">DjangoCon US 2022 Talks</a>
-        </li>
-        <li>
-          <a href="https://2021.djangocon.us/talks/">DjangoCon US 2021 Talks</a>
-        </li>
-        <li>
-          <a href="https://2019.djangocon.us/talks/">DjangoCon US 2019 Talks</a>
-        </li>
-      </ul>
+*   [DjangoCon US 2023 Talks](https://2023.djangocon.us/talks/)
+*   [DjangoCon US 2022 Talks](https://2022.djangocon.us/talks/)
+*   [DjangoCon US 2021 Talks](https://2021.djangocon.us/talks/)
+*   [DjangoCon US 2019 Talks](https://2019.djangocon.us/talks/)
 
-      <h4 id="online-talks">Online talks</h4>
+#### Online talks
 
-      <p>Just like in 2023, most talks will be in-person, and we will have several online-exclusive talks that air during breaks in the in-person session. These will air across all three talk days (Monday through Wednesday). Please indicate your preference for online or in-person in your submissions. There’s a required question in pretalx asking your preference.</p>
+Just like in 2023, most talks will be in-person, and we will have several online-exclusive talks that air during breaks in the in-person session. These will air across all three talk days (Monday through Wednesday). Please indicate your preference for online or in-person in your submissions. There’s a required question in pretalx asking your preference.
 
-      <h3 id="deep-dive-talks-september-25th">
-        Deep Dive Talks (September 25th)
-      </h3>
+### Deep Dive Talks (September 25th)
 
-      <p>This year, we will be curating a deep dive day to focus on exploring Django and Django-adjacent topics in detail.
-      Deep dive day is meant to follow in the footsteps of <a href="https://djangounderthehood.com/">Django Under the Hood</a> and will provide a range of topics presented in-depth, targeting varying levels of Django experience.
-      Talks of this nature will mix community submissions and personal invitations.
-      If you believe your talk is a good fit, please indicate so on your submission to our CFP by choosing the “deep dive” tag!</p>
+This year, we will be curating a deep dive day to focus on exploring Django and Django-adjacent topics in detail. Deep dive day is meant to follow in the footsteps of [Django Under the Hood](https://djangounderthehood.com/) and will provide a range of topics presented in-depth, targeting varying levels of Django experience. Talks of this nature will mix community submissions and personal invitations. If you believe your talk is a good fit, please indicate so on your submission to our CFP by choosing the “deep dive” tag!
 
-      <h3 id="tutorials-september-22">Tutorials (September 22nd)</h3>
+### Tutorials (September 22nd)
 
-      <ul>
-        <li>Length: 3-3.5 hours</li>
-        <li>Format: In-person</li>
-      </ul>
+*   Length: 3-3.5 hours
+*   Format: In-person
 
-      <p>We’re open to all kinds of ideas, especially ones we haven’t thought of! Technical tutorials tend to be more popular, but we welcome all topics! Tutorials can be targeted at any experience level, just be sure to indicate clearly what you expect your students to already know or have experience with in your proposal!</p>
+We’re open to all kinds of ideas, especially ones we haven’t thought of! Technical tutorials tend to be more popular, but we welcome all topics! Tutorials can be targeted at any experience level, just be sure to indicate clearly what you expect your students to already know or have experience with in your proposal!
 
-      <p>Still unsure if you should submit? Not only will we cover your DjangoCon ticket, but <em>tutorials are compensated</em>! However, they do not include the price of your travel or lodging. If you need help with these costs, fill out the <a href="https://forms.gle/Pi12J6vFQHq2CSAy5">opportunity grant</a> form by April 29, 2024. Decision notifications will be sent by June 14, 2024.</p>
+Still unsure if you should submit? Not only will we cover your DjangoCon ticket, but _tutorials are compensated_! However, they do not include the price of your travel or lodging. If you need help with these costs, fill out the [opportunity grant](https://forms.gle/Pi12J6vFQHq2CSAy5) form by April 29, 2024. Decision notifications will be sent by June 14, 2024.
 
-      <h4 id="new-expectations-for-tutorials">New Expectations for Tutorials</h4>
+#### New Expectations for Tutorials
 
-      <p>In order to streamline the tutorial process, we’re going to offer volunteer staffed office hours for tutorial attendees to help them get their machine set up. Tutorial presenters are not required to participate in these office hours. We will require that all tutorials include a setup guide by October 1st. This guide is what will be followed during the office hours.</p>
+In order to streamline the tutorial process, we’re going to offer volunteer staffed office hours for tutorial attendees to help them get their machine set up. Tutorial presenters are not required to participate in these office hours. We will require that all tutorials include a setup guide by October 1st. This guide is what will be followed during the office hours.
 
-      <p>The setup guide should include a step confirming that the setup has been complete. For example, if the tutorial requires a working Django application, having the user create a superuser, run <code class="language-plaintext highlighter-rouge">runserver</code>, then log into the Django Administration site would suffice. The goal here is to uncover and resolve setup issues so that the tutorial’s time can be spent on content. A thorough example for a setup guide <a href="https://github.com/tim-schilling/debug-tutorial/#getting-setup">can be found here</a>.</p>
+The setup guide should include a step confirming that the setup has been complete. For example, if the tutorial requires a working Django application, having the user create a superuser, run `runserver`, then log into the Django Administration site would suffice. The goal here is to uncover and resolve setup issues so that the tutorial’s time can be spent on content. A thorough example for a setup guide [can be found here](https://github.com/tim-schilling/debug-tutorial/#getting-setup).
 
+### Lightning Talks (September 23rd, 24th, & 25th)
 
-        <h3 id="lightning-talks-zap-september-23rd-24th--25th" class="flex flex-wrap">
-          Lightning Talks
-          (September 23rd, 24th, &amp; 25th)
-        </h3>
+Not up for a full-on talk or tutorial? Looking to give your first talk at a conference? Lightning talks are talks under 5 minutes with or without slides on almost any topic you want! Even if you’re nervous or shy, remember: it’s a **maximum** of 5 minutes. Sign-ups will happen at the conference.
 
-      <p>Not up for a full-on talk or tutorial? Looking to give your first talk at a conference?
-      Lightning talks are talks under 5 minutes with or without slides on almost any topic you want!
-      Even if you’re nervous or shy, remember: it’s a <strong>maximum</strong> of 5 minutes.
-      Sign-ups will happen at the conference.</p>
+### Speaker Travel Assistance
 
-      <h3 id="speaker-travel-assistance">Speaker Travel Assistance</h3>
+As we have in the past, this year, we have set aside up to $500 per speaker to help offset the cost of travel to the conference. In order to maximize the amount we can provide, we ask that speakers who will be reimbursed by their employer decline the assistance offered so it can be spread out among speakers who do not receive travel reimbursement. Receipts for travel expenses will be required.
 
-      <p>As we have in the past, this year, we have set aside up to $500 per speaker to help offset the cost of travel to the conference.
-      In order to maximize the amount we can provide, we ask that speakers who will be reimbursed by their employer decline the assistance offered so it can be spread out among speakers who do not receive travel reimbursement.
-      Receipts for travel expenses will be required.</p>
+### Online speaker gear reimbursement
 
-      <h3 id="online-speaker-gear-reimbursement">Online speaker gear reimbursement</h3>
+If you are speaking online, we are pleased to offer up to $500 for recording gear reimbursement to be used on qualifying expenses (camera, light, microphone, etc.). This cannot be used in conjunction with the above travel reimbursement (it’s an either/or proposition).
 
-      <p>If you are speaking online, we are pleased to offer up to $500 for recording gear reimbursement to be used on qualifying expenses (camera, light, microphone, etc.). This cannot be used in conjunction with the above travel reimbursement (it’s an either/or proposition).</p>
+## Pre-conference information
 
-      <h2 id="pre-conference-information">Pre-conference information</h2>
+You will have the option to upload a rough transcript of your talk approximately two weeks before the conference to give the captioning team a chance to train on any jargon you might use in your talk. This is by no means required but it will provide a more accessible experience to your audience.
 
-      <p>You will have the option to upload a rough transcript of your talk approximately two weeks before the conference to give the captioning team a chance to train on any jargon you might use in your talk. This is by no means required but it will provide a more accessible experience to your audience.</p>
-
-      <p>The organizing team reserves the right to request a review of draft slides at any point up to the start of the conference for any reason including but not limited to content, messaging quality, and more. Failure to provide these slides in a timely manner may result in your removal from the program. We understand that the slides are draft quality and will not be shared outside the program and code of conduct teams.</p>
+The organizing team reserves the right to request a review of draft slides at any point up to the start of the conference for any reason including but not limited to content, messaging quality, and more. Failure to provide these slides in a timely manner may result in your removal from the program. We understand that the slides are draft quality and will not be shared outside the program and code of conduct teams.
+      {% endmarkdown %}
   </div>
 </div>

--- a/src/speaking/speaker-resources.html
+++ b/src/speaking/speaker-resources.html
@@ -17,69 +17,59 @@ description: >
 <div class="pt-0 block-container">
   <div class="wrapper">
     <div class="prose lg:prose-lg">
-       
-      <h2 id="information-for-speakers">Information for Speakers</h2>
-        <ul>
-          <li>The Speaker Green Room will be in <strong>Meeting Room 2</strong> on Monday-Wednesday.</li>
-          <li>Please be in your presentation room at least 15 minutes before your talk to meet your session chair.</li>
-          <li>A Quiet Room will be available for attendees and speakers on all conference days.</li>
-          <li>We reserve the right to ask for a draft of your slides/notes not more than 3 weeks in advance of the presentation for review. This draft will not be shared with anyone outside the program and code of conduct teams.</li>
-        </ul>
+        {% markdown %}
+## Information for Speakers
 
-        <h2 id="need-some-help-with-your-presentation-">Need some help with your presentation?</h2>
-        <p>Presenters, regardless of experience, sometimes want a little help. If you’d like any help in preparing or presenting your talk, some awesome members of our community have volunteered to be speaker mentors. A mentor is an experienced presenter who has volunteered to help other presenters. For first-time presenters, non-native English speakers, under-confident or uncertain speakers, or anyone who would just appreciate another set of eyes, our mentors will be here to help. You’ll get the best results by forming a relationship with one mentor, rather than contacting several.</p>
-        <ul>
-          <li><a href="mailto:annabell.ossowski@gmail.com">Anna Ossowski</a>, Anna works as a Senior Community Program Manager at Github and actively volunteer across many different open source communities related to the Python Programming Language. This includes her former role on the Board of the Directors for the Python Software Foundation and as a current organizer for PyLadies in London. She’s a strong advocate for mental health and mentorship as well as supporting effective open source communities. Her newest hobby is writing and performing stand up comedy.</li>
-          <li><a href="mailto:frank@revsys.com">Frank Wiles</a>, Former President of the Board, Django Software Foundation, Founder, REVSYS.</li>
-        </ul>
+*   The Speaker Green Room will be in **Meeting Room 2** on Monday-Wednesday.
+*   Please be in your presentation room at least 15 minutes before your talk to meet your session chair.
+*   A Quiet Room will be available for attendees and speakers on all conference days.
+*   We reserve the right to ask for a draft of your slides/notes not more than 3 weeks in advance of the presentation for review. This draft will not be shared with anyone outside the program and code of conduct teams.
 
-        <!-- <ul>
-        <li><a href="mailto:eng@energy-solution.com">Eng Seng Ng</a>, Senior Engineer at Energy Solutions. Eng Seng leads the documentation and training team for a climate-change-fighting software product at Energy Solutions.</li>
-        <li><a href="mailto:katie+djangoconus@glasnt.com">Katie McLaughlin</a>, Developer Advocate and frequent public speaker (occasional keynoter), DjangoCon AU organiser, and Secretary for the Django Software Foundation.</li>
-        <li><a href="mailto:pjj@philipjohnjames.com">Philip James</a>, Core Contributor to the BeeWare project and Senior Software Engineer at Patreon. Philip has spoken at a number of DjangoCons and PyCons around the world.</li>
-        <li><a href="mailto:russell@keith-magee.com">Dr. Russell Keith-Magee</a>, Founder of the BeeWare project, developing GUI tools and libraries to support the development of Python software on desktop and mobile platforms. He is also a 13 year veteran of the Django Core Team, and for 5 years, was President of the Django Software Foundation. In his day job, he wrangles data pipelines for Survata.
-        </li>
-        </ul> -->
-        
-        <h2 id="talk-guidelines">Talk Guidelines</h2>
-        <h3 id="accessibility">Accessibility</h3>
-        <ul>
-        <li>You can submit a draft copy of your slides with notes indicating what you plan to say a minimum of three weeks before your talk to give the captioners time to train on your data and therefore improve caption accuracy. This is extremely helpful to our attendees who read the live captions if you&#39;re using jargon beyond &quot;Django&quot; and &quot;the ORM&quot;.</li>
-        <li>These slides will not be shared outside of the organizing team and the captioners. Send the slides to hello AT djangocon DOT us when you are ready. It&#39;s perfectly fine if your slides and notes change between the draft and final version.</li>
-        <li>When describing media in your talk (images, screenshots, graphs, videos, etc.), please give a verbal description of what you&#39;re showing so that blind or vision-impaired attendees can understand what you&#39;re describing.<ul>
-        <li>Example: instead of &quot;here&#39;s a graph showing performance improvements with our new async code,&quot; say &quot;here&#39;s a line graph showing our average response time that decreased from 450 milliseconds to 150 milliseconds after adding our new async code.&quot;</li>
-        </ul>
-        </li>
-        </ul>
-        <h3 id="general">General</h3>
-        <ul>
-        <li>Use gender-neutral language wherever possible. Don&#39;t default to <a href="https://heyguys.cc">using &quot;he&quot;, &quot;him&quot;, or &quot;guys&quot;</a> everywhere.</li>
-        <li>Be respectful of other speakers, your audience, and the community at large, especially when offering critiques. It&#39;s possible to say &quot;this needs improvement&quot; without saying &quot;this is bad.&quot;</li>
-        <li>Consider including your social media handle(s) on your opening and closing slides! If you have space, you can even include them on the footer of every slide.</li>
-        <li>Consider publishing your slides after your talk (on the platform of your choice) and sharing the link with the #DjangoCon hashtag on social media.</li>
-        <li>Include a copy of what you plan to say in each slide&#39;s notes (if possible). This will help you while you&#39;re in presenter view and also make it easier for people who may be looking at your slides after the conference.</li>
-        <li>Before you connect your laptop to the projector, make sure you have every window except for your slides minimized or closed to avoid accidental information disclosure.</li>
-        <li>Make sure you turn on your computer&#39;s do not disturb mode before starting your presentation to avoid interruptions.</li>
-        <li>If your computer needs a dongle to connect to an HDMI cable, please bring it. We&#39;ll have most of the common ones, including a USB-C/Thunderbolt connector, but it always helps to have one that you know works.</li>
-        </ul>
-        <h2 id="slide-guidelines">Slide Guidelines</h2>
-        <h3 id="format">Format</h3>
-        <ul>
-        <li>Minimal slides are best—-avoid walls of text and long lists of bullets.</li>
-        <li>Light background with dark text is easiest to read; be mindful that the projection screen is white.
-        Choose fonts with adequate spacing between letters, and avoid thin or cursive fonts.</li>
-        <li>Leave the bottom 25% of your slides free of text to ensure nothing is obscured by other attendees&#39; heads.</li>
-        <li>If your talk requires live coding or using the terminal, make sure your editor or terminal settings are legible. Dark text on a light background (high contrast) with a large font is best.</li>
-        <li>Images, memes, and GIFs should be appropriate for a professional audience.</li>
-        </ul>
-        <h3 id="accessibility">Accessibility</h3>
-        <ul>
-        <li>Aim for high contrast slides, avoiding colors that may be difficult to see for those with colorblindness. (You can <a href="http://webaim.org/resources/contrastchecker/">check your contrast online</a>; you just need the hex codes for your colors!)</li>
-        <li>Avoid or limit flashing videos or animated GIFs, as these may have negative effects for people with seizure disorders, migraines, or ADD/ADHD.</li>
-        <li>Make text as large as possible. People need to be able to read the text from a very long distance.</li>
-        <li>Your talk should lose nothing if the slides aren’t visible. Generally describe graphs, images, and other information for the audience.</li>
-        </ul>
-        <p>Thanks to <a href="https://www.alterconf.com/speak">AlterConf</a> for their amazing speaking recommendations!</p>
+## Need some help with your presentation?
 
+Presenters, regardless of experience, sometimes want a little help. If you’d like any help in preparing or presenting your talk, some awesome members of our community have volunteered to be speaker mentors. A mentor is an experienced presenter who has volunteered to help other presenters. For first-time presenters, non-native English speakers, under-confident or uncertain speakers, or anyone who would just appreciate another set of eyes, our mentors will be here to help. You’ll get the best results by forming a relationship with one mentor, rather than contacting several.
+
+*   [Anna Ossowski](mailto:annabell.ossowski@gmail.com), Anna works as a Senior Community Program Manager at Github and actively volunteer across many different open source communities related to the Python Programming Language. This includes her former role on the Board of the Directors for the Python Software Foundation and as a current organizer for PyLadies in London. She’s a strong advocate for mental health and mentorship as well as supporting effective open source communities. Her newest hobby is writing and performing stand up comedy.
+*   [Frank Wiles](mailto:frank@revsys.com), Former President of the Board, Django Software Foundation, Founder, REVSYS.
+
+## Talk Guidelines
+
+### Accessibility
+
+*   You can submit a draft copy of your slides with notes indicating what you plan to say a minimum of three weeks before your talk to give the captioners time to train on your data and therefore improve caption accuracy. This is extremely helpful to our attendees who read the live captions if you're using jargon beyond "Django" and "the ORM".
+*   These slides will not be shared outside of the organizing team and the captioners. Send the slides to hello AT djangocon DOT us when you are ready. It's perfectly fine if your slides and notes change between the draft and final version.
+*   When describing media in your talk (images, screenshots, graphs, videos, etc.), please give a verbal description of what you're showing so that blind or vision-impaired attendees can understand what you're describing.
+*   Example: instead of "here's a graph showing performance improvements with our new async code," say "here's a line graph showing our average response time that decreased from 450 milliseconds to 150 milliseconds after adding our new async code."
+
+### General
+
+*   Use gender-neutral language wherever possible. Don't default to [using "he", "him", or "guys"](https://heyguys.cc) everywhere.
+*   Be respectful of other speakers, your audience, and the community at large, especially when offering critiques. It's possible to say "this needs improvement" without saying "this is bad."
+*   Consider including your social media handle(s) on your opening and closing slides! If you have space, you can even include them on the footer of every slide.
+*   Consider publishing your slides after your talk (on the platform of your choice) and sharing the link with the #DjangoCon hashtag on social media.
+*   Include a copy of what you plan to say in each slide's notes (if possible). This will help you while you're in presenter view and also make it easier for people who may be looking at your slides after the conference.
+*   Before you connect your laptop to the projector, make sure you have every window except for your slides minimized or closed to avoid accidental information disclosure.
+*   Make sure you turn on your computer's do not disturb mode before starting your presentation to avoid interruptions.
+*   If your computer needs a dongle to connect to an HDMI cable, please bring it. We'll have most of the common ones, including a USB-C/Thunderbolt connector, but it always helps to have one that you know works.
+
+## Slide Guidelines
+
+### Format
+
+*   Minimal slides are best—-avoid walls of text and long lists of bullets.
+*   Light background with dark text is easiest to read; be mindful that the projection screen is white. Choose fonts with adequate spacing between letters, and avoid thin or cursive fonts.
+*   Leave the bottom 25% of your slides free of text to ensure nothing is obscured by other attendees' heads.
+*   If your talk requires live coding or using the terminal, make sure your editor or terminal settings are legible. Dark text on a light background (high contrast) with a large font is best.
+*   Images, memes, and GIFs should be appropriate for a professional audience.
+
+### Accessibility
+
+*   Aim for high contrast slides, avoiding colors that may be difficult to see for those with colorblindness. (You can [check your contrast online](http://webaim.org/resources/contrastchecker/); you just need the hex codes for your colors!)
+*   Avoid or limit flashing videos or animated GIFs, as these may have negative effects for people with seizure disorders, migraines, or ADD/ADHD.
+*   Make text as large as possible. People need to be able to read the text from a very long distance.
+*   Your talk should lose nothing if the slides aren’t visible. Generally describe graphs, images, and other information for the audience.
+
+Thanks to [AlterConf](https://www.alterconf.com/speak) for their amazing speaking recommendations!
+        {% endmarkdown %}
   </div>
 </div>


### PR DESCRIPTION
- Adds a shortcode, `{% markdown %}` that allows Markdown in HTML files.
- Standardizes Markdown configuration across the project in the markdown.js file.
- Converts Speaking pages to Markdown for demonstration.