### PR TITLE
Clarify verbiage on tutorial speakers getting compensated

### DIFF
--- a/src/speaking/index.html
+++ b/src/speaking/index.html
@@ -74,7 +74,7 @@ This year, we will be curating a deep dive day to focus on exploring Django and 
 
 We’re open to all kinds of ideas, especially ones we haven’t thought of! Technical tutorials tend to be more popular, but we welcome all topics! Tutorials can be targeted at any experience level, just be sure to indicate clearly what you expect your students to already know or have experience with in your proposal!
 
-Still unsure if you should submit? Not only will we cover your DjangoCon ticket, but _tutorials are compensated_! However, they do not include the price of your travel or lodging. If you need help with these costs, fill out the [opportunity grant](https://forms.gle/Pi12J6vFQHq2CSAy5) form by April 29, 2024. Decision notifications will be sent by June 14, 2024.
+Still unsure if you should submit? Not only will we cover your DjangoCon ticket, but _tutorials are compensated_!  Presenters get paid a portion of the ticket sales for their tutorial.
 
 #### New Expectations for Tutorials
 


### PR DESCRIPTION
Tutorial presenters aren't generally eligible for opportunity grants because we're paying them to present. Let's not encourage them to apply for grants as such.