### PR TITLE
Reusable Django Template Components for Perfectionists with Deadlines changes

### DIFF
--- a/src/_content/schedule/talks/reusable-django-template-components-for-perfectionists-with-deadlines.md
+++ b/src/_content/schedule/talks/reusable-django-template-components-for-perfectionists-with-deadlines.md
@@ -8,11 +8,11 @@ presenter_slugs:
 room: Online talks
 tags:
 - frontend
-title: Reusable Django Template Components for Perfectionists with Deadlines
+title: Django UI Components for Perfectionists with Deadlines
 track: t2
 ---
 
 We pay great attention to how to write composable python code (with inheritance, decorators, modules, namespaces, etc). But when it comes to architecting the templates of your website, this is often overlooked, which rapidly degenerates in tons of copy&paste of html, css and javascript.
 Some might say that this is what React or Vue (et al) are all about and already solve, but having to render HTML on the client can increase the complexity of the application (introducing build steps, another language, more dependencies, etc).
   
-Writing reusable and composable UI components can be achieved using the good 'ol django templates, with the help of some libraries to fill in the gaps (like django-components, wagtail blocks, crispy-forms with their templates, tailwindcss) that we will explore and suggest as a possible solution.
+Writing reusable and composable UI components can be achieved using the good 'ol django templates, with the help of some libraries to fill in the gaps (like django-components, django-cotton and TailwindCSS) that we will explore and suggest as a possible solution.


### PR DESCRIPTION
Dear DjangoCon organizers,

I noticed that the title was a bit long so I decided to change it to: Django UI Components for Perfectionists with Deadlines

I also noticed that some other talks would cover in more detail some of the topics I wanted to cover (like forms for example), so I would like to make a small change to the description of the talk to name the specific libraries being presented.

Thanks
