### PR TITLE
Help page venueless

### DIFF
--- a/src/venueless-help-page.html
+++ b/src/venueless-help-page.html
@@ -14,13 +14,12 @@ description: Find Help
       <div class="flex-1 max-w-screen-lg">
         <h1 class="mb-8 pageheading">{{ title }}</h1>
         <p class="subheading">
-          Need Help? This is the place! Or, the go to <a href="https://djangoconus2024.slack.com">Slack</a> Page.
+          Need Help? This is the place! Or, go to the <a href="https://djangoconus2024.slack.com">Slack</a> Page.
         </p>
       </div>
     </header>
   </div>
 </div>
-
 <div class="block-container bg-blue">
   <div class="wrapper">
     <div class="grid gap-4 lg:grid-cols-4">

--- a/src/venueless-help-page.html
+++ b/src/venueless-help-page.html
@@ -23,15 +23,23 @@ description: Find Help
 
 <div class="block-container bg-blue">
   <div class="wrapper">
-    <div class="grid grid-cols-4 gap-4 lg:grid-cols-4">
-        <div class="p-4 bg-gray-100 font-bold">General Venuless Questions?</div>
-        <p class="p-4 bg-gray-100">Come Visit Our Help Desk in <a href="https://djangoconus2024.slack.com">Slack </a></p>
-        <div class="p-4 bg-gray-200 font-bold">Technical Issues?</div>
-        <p class="col-start- p-4 bg-gray-100">Come Visit Our Help Desk in <a href="https://djangoconus2024.slack.com">Slack </a></p>
-        <div class="p-4 bg-gray-200 font-bold">Problems Accessing Slack?</div>
-        <p class="col-start- p-4 bg-gray-100">Email Us!! <a href="mailto:{{site.contact_us_email}}">hello@djangocon.us</a></p>
-        <div class="p-4 bg-gray-200 font-bold">Code of Conduct Issues?</div>
-        <p class="col-start- p-4 bg-gray-100">Visit Our <a href="">Code of Conduct Page.</a></p>
+    <div class="grid gap-4 lg:grid-cols-4">
+        <div class="p-4 bg-gray-100">
+          <span class="text-xl font-bold">General Venueless Questions?</span>
+          <p class="">Come Visit Our Help Desk in <a href="https://djangoconus2024.slack.com">Slack </a></p>
+        </div>
+        <div class="p-4 bg-gray-200">
+          <span class="text-xl font-bold">Technical Issues?</span>
+          <p>Come Visit Our Help Desk in <a href="https://djangoconus2024.slack.com">Slack </a></p>
+        </div>
+        <div class="p-4 bg-gray-200">
+          <span class="text-xl font-bold">Problems Accessing Slack?</span>
+          <p>Email Us!! <a href="mailto:{{site.contact_us_email}}">hello@djangocon.us</a></p>
+        </div>
+        <div class="p-4 bg-gray-200">
+          <span class="text-xl font-bold">Code of Conduct Issues?</span>
+          <p>Visit Our <a href="">Code of Conduct Page.</a></p>
+        </div>
       </div>
     </div>
   </div>

--- a/src/venueless-help-page.html
+++ b/src/venueless-help-page.html
@@ -14,13 +14,13 @@ description: Find Help
       <div class="flex-1 max-w-screen-lg">
         <h1 class="mb-8 pageheading">{{ title }}</h1>
         <p class="subheading">
-          Need Help? This is the place! Or the go to <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack</a> Page.
+          Need Help? This is the place! Or, the go to <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack</a> Page.
         </p>
       </div>
     </header>
   </div>
 </div>
-<div class="bg-gray-100 block-container">
+<!-- <div class="bg-gray-100 block-container">
   <div class="wrapper">
     <div class="flex items-center justify-center min-h-screen">
       <div class="gap-8 list-disc lg:gap-16 md:columns-2 prose lg:prose-lg *:break-inside-avoid">
@@ -33,6 +33,21 @@ description: Find Help
           <p>Code of Conduct Issues?</p>
           <p>Visit Our <a href="">Code of Conduct Page.</a></p>
         </div>
+    </div>
+  </div>
+</div> -->
+<div class="block-container bg-blue">
+  <div class="wrapper">
+    <div class="grid grid-cols-4 gap-4 lg:grid-cols-4">
+        <div class="p-4 bg-gray-100 font-bold">General Venuless Questions?</div>
+        <p class="p-4 bg-gray-100">Come Visit Our Help Desk in <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack </a></p>
+        <div class="p-4 bg-gray-200 font-bold">Technical Issues?</div>
+        <p class="col-start- p-4 bg-gray-100">Come Visit Our Help Desk in <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack </a></p>
+        <div class="p-4 bg-gray-200 font-bold">Problems Accessing Slack?</div>
+        <p class="col-start- p-4 bg-gray-100">Email Us!! <a href="mailto:{{site.contact_us_email}}">hello@djangocon.us</a></p>
+        <div class="p-4 bg-gray-200 font-bold">Code of Conduct Issues?</div>
+        <p class="col-start- p-4 bg-gray-100">Visit Our <a href="">Code of Conduct Page.</a></p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/venueless-help-page.html
+++ b/src/venueless-help-page.html
@@ -37,9 +37,8 @@ description: Find Help
         </div>
         <div class="p-4 bg-gray-200">
           <span class="text-xl font-bold">Code of Conduct Issues?</span>
-          <p>Visit Our <a href="">Code of Conduct Page.</a></p>
+          <p>Visit Our <a href="/conduct/">Code of Conduct Page.</a></p>
         </div>
       </div>
     </div>
   </div>
-</div>

--- a/src/venueless-help-page.html
+++ b/src/venueless-help-page.html
@@ -14,35 +14,20 @@ description: Find Help
       <div class="flex-1 max-w-screen-lg">
         <h1 class="mb-8 pageheading">{{ title }}</h1>
         <p class="subheading">
-          Need Help? This is the place! Or, the go to <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack</a> Page.
+          Need Help? This is the place! Or, the go to <a href="https://djangoconus2024.slack.com">Slack</a> Page.
         </p>
       </div>
     </header>
   </div>
 </div>
-<!-- <div class="bg-gray-100 block-container">
-  <div class="wrapper">
-    <div class="flex items-center justify-center min-h-screen">
-      <div class="gap-8 list-disc lg:gap-16 md:columns-2 prose lg:prose-lg *:break-inside-avoid">
-          <p>General Venuless Questions?</p>
-          <p>Come Visit Our Help Desk in <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack </a></p>
-          <p>Technical Issues?</p>
-          <p>Come Visit Our Help Desk in <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack </a></p>
-          <p>Problems Accessing Slack?</p>
-          <p>Email Us!! <a href="mailto:{{site.contact_us_email}}">hello@djangocon.us</a> </p>
-          <p>Code of Conduct Issues?</p>
-          <p>Visit Our <a href="">Code of Conduct Page.</a></p>
-        </div>
-    </div>
-  </div>
-</div> -->
+
 <div class="block-container bg-blue">
   <div class="wrapper">
     <div class="grid grid-cols-4 gap-4 lg:grid-cols-4">
         <div class="p-4 bg-gray-100 font-bold">General Venuless Questions?</div>
-        <p class="p-4 bg-gray-100">Come Visit Our Help Desk in <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack </a></p>
+        <p class="p-4 bg-gray-100">Come Visit Our Help Desk in <a href="https://djangoconus2024.slack.com">Slack </a></p>
         <div class="p-4 bg-gray-200 font-bold">Technical Issues?</div>
-        <p class="col-start- p-4 bg-gray-100">Come Visit Our Help Desk in <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack </a></p>
+        <p class="col-start- p-4 bg-gray-100">Come Visit Our Help Desk in <a href="https://djangoconus2024.slack.com">Slack </a></p>
         <div class="p-4 bg-gray-200 font-bold">Problems Accessing Slack?</div>
         <p class="col-start- p-4 bg-gray-100">Email Us!! <a href="mailto:{{site.contact_us_email}}">hello@djangocon.us</a></p>
         <div class="p-4 bg-gray-200 font-bold">Code of Conduct Issues?</div>

--- a/src/venueless-help-page.html
+++ b/src/venueless-help-page.html
@@ -1,0 +1,38 @@
+---
+layout: default
+title: Help Page
+description: Find Help
+---
+
+<div class="hero">
+  <div class="wrapper">
+    <header class="flex flex-wrap items-center gap-8 lg:gap-16">
+      <img
+        src="/assets/img/theme/hero-img.webp"
+        alt="welcome"
+        class="hidden w-full max-w-80 md:block" />
+      <div class="flex-1 max-w-screen-lg">
+        <h1 class="mb-8 pageheading">{{ title }}</h1>
+        <p class="subheading">
+          Need Help? This is the place! Or the go to <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack</a> Page.
+        </p>
+      </div>
+    </header>
+  </div>
+</div>
+<div class="bg-gray-100 block-container">
+  <div class="wrapper">
+    <div class="flex items-center justify-center min-h-screen">
+      <div class="gap-8 list-disc lg:gap-16 md:columns-2 prose lg:prose-lg *:break-inside-avoid">
+          <p>General Venuless Questions?</p>
+          <p>Come Visit Our Help Desk in <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack </a></p>
+          <p>Technical Issues?</p>
+          <p>Come Visit Our Help Desk in <a href="https://join.slack.com/t/djangoconus2024/shared_invite/zt-2qh4h5fgg-m4HbkbtNWBSm2Kq3nG~7yQ">Slack </a></p>
+          <p>Problems Accessing Slack?</p>
+          <p>Email Us!! <a href="mailto:{{site.contact_us_email}}">hello@djangocon.us</a> </p>
+          <p>Code of Conduct Issues?</p>
+          <p>Visit Our <a href="">Code of Conduct Page.</a></p>
+        </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Created a help page for venueless in the website to have one source of truth and maintain a consistent appearance since the other pages (COC & Sponsors) also come from our website.


![Screenshot 2024-09-14 at 08-42-41 Help Page](https://github.com/user-attachments/assets/d8500fbc-0456-41f8-8a95-29dcedb203cc)
