### PR TITLE
⚠️ Remove embedded videos of the conference

### DIFF
--- a/src/_layouts/session.html
+++ b/src/_layouts/session.html
@@ -40,6 +40,26 @@
 
   <div class="py-8 bg-gray-50 lg:py-10 block-container">
     <div class="wrapper narrow">
+      <section class="flex flex-wrap justify-center gap-4 p-8">
+        <section class="p-4 bg-orange-100 rounded">
+          <h3 class="mb-4 text-lg font-bold font-heading lg:text-2xl">We're sorry!</h3>
+          <div class="prose prose-lg">
+            <p>
+              We made a mistake in processing the videos from DjangoCon US 2024. The sponsor
+              acknowledgements are missing our wonderful sponsor Wharton School of Business.
+              We deeply regret this and are working to re-upload videos with our correct
+              sponsor acknowledgements.
+            </p>
+            <p>
+              All videos have been marked as unlisted and will be removed in the future.
+              We expect the new, permanent videos to be uploaded in two weeks.
+            </p>
+          </div>
+        </section>
+      </section>
+      {% comment %}
+      Remove once we fix the sponsor credits in the youtube videos
+
       {% if video_url %}
         {% assign youtube_id = video_url | replace:"https://youtu.be/","" %}
         <figure class="aspect-video">
@@ -71,6 +91,7 @@
           {% endif %}
         </section>
       {% endif %}
+      {% endcomment %}
 
 
       <h2 class="mb-6 text-xl font-bold leading-tight lg:text-3xl">About this session</h2>

--- a/src/_layouts/session.html
+++ b/src/_layouts/session.html
@@ -46,7 +46,7 @@
           <div class="prose prose-lg">
             <p>
               We made a mistake in processing the videos from DjangoCon US 2024. The sponsor
-              acknowledgements are missing our wonderful sponsor, the Wharton School of Business.
+              acknowledgements are missing our wonderful sponsor, the Wharton School.
               We deeply regret this and are working to re-upload videos with our correct
               sponsor acknowledgements.
             </p>

--- a/src/_layouts/session.html
+++ b/src/_layouts/session.html
@@ -46,7 +46,7 @@
           <div class="prose prose-lg">
             <p>
               We made a mistake in processing the videos from DjangoCon US 2024. The sponsor
-              acknowledgements are missing our wonderful sponsor Wharton School of Business.
+              acknowledgements are missing our wonderful sponsor, the Wharton School of Business.
               We deeply regret this and are working to re-upload videos with our correct
               sponsor acknowledgements.
             </p>


### PR DESCRIPTION
This is temporary until we get Wharton included as a sponsor for the DjangoCon US 2024 sponsors. At that point, the new video_urls should be added and this commit reverted.

This didn't change the video_urls to effectively only inject this warning for the talks and not the tutorials.

![Screenshot from 2024-11-13 13-46-42](https://github.com/user-attachments/assets/d73b8cc3-1afa-439e-9f7e-cfe1e20a8fd6)
